### PR TITLE
Allow for TS_ADVERTISE_ROUTES with --advertise-exit-node

### DIFF
--- a/updatestate.sh
+++ b/updatestate.sh
@@ -43,8 +43,17 @@ if [[ -z "${TS_ADVERTISE_ROUTES}" ]]; then
 fi
 
 if [[ $TS_ADVERTISE_ROUTES == *"0.0.0.0/0"* ]]; then
-  echo "[wgts] Advertising exit node"
-  tailscale set --advertise-routes="" --advertise-exit-node --accept-routes=false
+  # remove the exit-node routes (0.0.0.0/0 & ::/0)
+  EXTRA_TS_ADVERTISE_ROUTES="${TS_ADVERTISE_ROUTES//0.0.0.0\/0/}"
+  EXTRA_TS_ADVERTISE_ROUTES="${EXTRA_TS_ADVERTISE_ROUTES//::\/0/}"
+
+  # Remove trailing, leading, or duplicate commas
+  EXTRA_TS_ADVERTISE_ROUTES="${EXTRA_TS_ADVERTISE_ROUTES//,,/,}"
+  EXTRA_TS_ADVERTISE_ROUTES="${EXTRA_TS_ADVERTISE_ROUTES#,}"
+  EXTRA_TS_ADVERTISE_ROUTES="${EXTRA_TS_ADVERTISE_ROUTES%,}"
+
+  echo "[wgts] Advertising exit node w/ \"$EXTRA_TS_ADVERTISE_ROUTES\""
+  tailscale set --advertise-routes="$EXTRA_TS_ADVERTISE_ROUTES" --advertise-exit-node=true --accept-routes=false
 else
   echo "[wgts] Advertising routes: ${TS_ADVERTISE_ROUTES}"
   tailscale set --advertise-routes="$TS_ADVERTISE_ROUTES" --advertise-exit-node=false --accept-routes=false


### PR DESCRIPTION
My use case called for `--advertise-routes="192.168.0.0/24" --advertise-exit-node` with the end goal of exposing the exit node's LAN to peers and routing outbound traffic through my third party VPN.

The original script here makes that a bit difficult. My "fix" is a hack in and of itself, but i thought it worth creating this PR to highlight my use case if nothing else.

The change allows for the following:
```
TS_ADVERTISE_ROUTES=192.168.0.0/24,0.0.0.0/0
```
updatestat.sh will detect then strip any references to `0.0.0.0/0` and `::/0` from the value of  `TS_ADVERTISE_ROUTES`, use the stripped value for `--advertise-routes` and set `--advertise-exit-node`. Works so far on my end.